### PR TITLE
Fixes compile errors on windows

### DIFF
--- a/command/execute_command.odin
+++ b/command/execute_command.odin
@@ -51,6 +51,7 @@ Example Usage:
 ```
 */
 run_executable :: proc(command: string, stdout: ^[]byte) -> (u32, bool, []byte) {
+	exit_code: u32 = 0
 	when ODIN_OS == .Windows {
 		stdout_read: win32.HANDLE
 		stdout_write: win32.HANDLE
@@ -113,13 +114,9 @@ run_executable :: proc(command: string, stdout: ^[]byte) -> (u32, bool, []byte) 
 
 		stdout[index + 1] = 0
 
-		exit_code: u32
-
 		win32.WaitForSingleObject(process_info.hProcess, win32.INFINITE)
 		win32.GetExitCodeProcess(process_info.hProcess, &exit_code)
 		win32.CloseHandle(stdout_read)
-
-		return exit_code, true, stdout[0:index]
 	}
 	when ODIN_OS == .Darwin || ODIN_OS == .Linux || ODIN_OS == .NetBSD {
 		fp := popen(strings.clone_to_cstring(command, context.temp_allocator), "r")
@@ -139,6 +136,6 @@ run_executable :: proc(command: string, stdout: ^[]byte) -> (u32, bool, []byte) 
 				mem.copy(&stdout[index], &read_buffer[0], cast(int)read)
 			}
 		}
-		return 0, true, stdout[0:index]
 	}
+	return exit_code, true, stdout[0:index]
 }

--- a/file_dialog/file_dialog_windows.odin
+++ b/file_dialog/file_dialog_windows.odin
@@ -4,11 +4,11 @@ import "core:strings"
 import win32 "core:sys/windows"
 import glfw "vendor:glfw"
 
-EngineInstance: ^glfw.Window
+file_dialog_window: ^glfw.Window
 
 open_file_dialog :: proc(filter: ..string, directory: bool = false) -> string {
 	when ODIN_OS == .Windows {
-		window := glfw.GetWin32Window(EngineInstance.window)
+		window := glfw.GetWin32Window(file_dialog_window.window)
 	}
 
 	file := [260]win32.WCHAR{}

--- a/file_dialog/file_dialog_windows.odin
+++ b/file_dialog/file_dialog_windows.odin
@@ -4,8 +4,12 @@ import "core:strings"
 import win32 "core:sys/windows"
 import glfw "vendor:glfw"
 
-open_file_dialog :: proc(filter: ..string) -> string {
-	window := glfw.GetWin32Window(EngineInstance.window)
+EngineInstance: ^glfw.Window
+
+open_file_dialog :: proc(filter: ..string, directory: bool = false) -> string {
+	when ODIN_OS == .Windows {
+		window := glfw.GetWin32Window(EngineInstance.window)
+	}
 
 	file := [260]win32.WCHAR{}
 


### PR DESCRIPTION
Compiles errors found by Magna on the Odin discord.

```odin
SpyPlayer/file_dialog/file_dialog_windows.odin(8:32) Error: Undeclared name: EngineInstance
        window := glfw.GetWin32Window(EngineInstance.window)

SpyPlayer/playlist.odin(15:50) Error: No parameter named 'directory' for this procedure type
        ... older := file_dialog.open_file_dialog("*.mp3", directory = true)

SpyPlayer/file_dialog/file_dialog_windows.odin(57:30) Error: Undeclared name: EngineInstance
        hwnd := glfw.GetWin32Window(EngineInstance.window)

SpyPlayer/command/execute_command.odin(144:1) Error: Missing return statement at the end of the procedure 'run_executable'
        }
```